### PR TITLE
Support Redmine4.0

### DIFF
--- a/lib/emoji_plugin.rb
+++ b/lib/emoji_plugin.rb
@@ -1,16 +1,12 @@
 module EmojiPlugin
   module Patch
     def self.included(base)
-      base.send(:include, InstanceMethods)
-      base.class_eval do
-        unloadable
-        alias_method_chain :to_html, :emoji
-      end
+      base.prepend(InstanceMethods)
     end
 
     module InstanceMethods
-      def to_html_with_emoji
-        html = to_html_without_emoji
+      def to_html(*args)
+        html = super(*args)
         html.gsub(/:([^:\s]+):/) do |match|
           icon = $1
           if Emoji.names.include?(icon)


### PR DESCRIPTION
Remine4.0(Rails5.2)では`alias_method_chain`が廃止されてしまっているため、prependを使った書き方に修正しました。