### PR TITLE
Fix load failure

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,3 @@
-require 'emoji_plugin'
-
 Redmine::Plugin.register :redmine_emoji do
   name 'Redmine Emoji plugin'
   author 'suer'


### PR DESCRIPTION
Redmine 5.6.0.stableにおいて `lib` ディレクトリ配下の `emoji_plugin` をrequireできずプラグインのロードに失敗するため、このrequireを削除しました。このrequireはなくてもRedmineがプラグインの `lib` ディレクトリをautoload pathに追加するため、動作に問題はないと思われます (念のためRedmine 4.0.9.stableでも動作確認しました) 。
軽く調べただけなので間違っているかもしれませんが、 [`redmine/redmine@838e719`](https://github.com/redmine/redmine/commit/838e719edfb2190c5ccc86accacef2ad57b39762) で各プラグインの `lib` ディレクトリが `$LOAD_PATH` に追加されなくなったのが原因かと思いました。